### PR TITLE
add format function to hande all formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @exuus/rwanda-phone-utils
 
-This is a simple npm package that validates the structure and format phone numbers from Rwanda.
+This is a simple npm package that validates and format the structure of phone numbers from Rwanda.
 
 [![NPM](https://nodei.co/npm/@exuus/rwanda-phone-utils.png)](https://nodei.co/npm/@exuus/rwanda-phone-utils/)
 
@@ -20,9 +20,9 @@ yarn add @exuus/rwanda-phone-utils
 
 ```js
 // Load full build
-import phone from "@exuus/rwanda-phone-utils";
+import phoneUtils from "@exuus/rwanda-phone-utils";
 
-console.log(phone("0780000000"));
+phoneUtils("0780000000")
 // {
 //     isValid: true,
 //     error: null,
@@ -31,133 +31,63 @@ console.log(phone("0780000000"));
 //     telco: "MTN",
 //     short: "780000000",
 //     dashed: "+(250)-780-000-000",
+//     format: function
 // }
 
-console.log(phone("80000000"));
+phoneUtils("80000000");
 // {
 //     isValid: false,
 //     error: "Phone number is invalid",
-//     normalized: "80000000",
+//     normalized: null,
 //     formatted: null,
+//     unformatted: 80000000,
 //     telco: null,
 //     short: null,
 //     dashed: null
+//     format: function
 // }
 ```
 
-# Methods
+# Format
+Get the formatted phone number according to the option (shape) passed in.
 
-## isValid()
+```js 
+phoneUtils("+250780000000").format() // default
+// 780000000
 
-```js
-import { isValid } from "@exuus/rwanda-phone-utils";
-
-console.log(isValid("0780000000"));
-// true
+phoneUtils("+250788000000").format("dashed-normalized")
+// 0780-000-000
 ```
 
-Or
 
+List of all available formats
+
+| **Format**             | **Output**           |
+|------------------------|----------------------|
+| `short`                | 780000000            |
+| `normalized`           | 0780000000           |
+| `dashed`               | +(250)-795-844-487   |
+| `dashed-short`         | 795-844-487          |
+| `dashed-normalized`    | 0795-844-487         |
+| `dashed-unformatted`   | 250-795-844-487      |
+| `space`                | +(250) 795 844 487   |
+| `space-short`          | 795 844 487          |
+| `space-normalized`     | 0795 844 487         |
+| `space-unformatted`    | 250 795 844 487      |
+
+
+Formatting an invalid number will give your an error message 
 ```js
-phone("0780000000").isValid;
+phoneUtils("+1780000000").format("short")
+// Phone number is invalid
 ```
 
-## format()
-
-```js
-import { format } from "@exuus/rwanda-phone-utils";
-
-console.log(format("0780000000"));
-// "(+250) 780 000 000"
-```
-
-Or
-
-```js
-phone("0780000000").formatted;
-```
-
-## normalize()
-
-```js
-import { normalize } from "@exuus/rwanda-phone-utils";
-
-console.log(normalize("0780000000"));
-// "0780000000"
-```
-
-Or
-
-```js
-phone("0780000000").normalized;
-```
-
-## short()
-
-```js
-import { short } from "@exuus/rwanda-phone-utils";
-
-console.log(short("0780000000"));
-// "780000000"
-```
-
-Or
-
-```js
-phone("0780000000").short;
-```
-
-## telco()
-
-```js
-import { telco } from "@exuus/rwanda-phone-utils";
-
-console.log(telco("0780000000"));
-// "MTN"
-```
-
-Or
-
-```js
-phone("0780000000").telco;
-```
-
-## telco()
-
-```js
-import { dashed } from "@exuus/rwanda-phone-utils";
-
-console.log(dashed("0780000000"));
-// "+(250)-780-000-000"
-```
-
-Or
-
-```js
-phone("0780000000").dashed;
-```
-
-## phone()
-
-```js
-import phone from "@exuus/rwanda-phone-utils";
-
-console.log(phone("0780000000"));
-// {
-//     isValid: true,
-//     error: null,
-//     normalized: "0780000000",
-//     formatted: "(+250) 780 000 000",
-//     telco: "MTN",
-//     short: "780000000",
-//     dashed: "+(250)-780-000-000"
-// }
-```
 
 # Contributors
 
-| [<img src="https://github.com/eliemugenzi.png" width="100px;"><br><sub><b>Elie Mugenzi</b></sub>](https://github.com/eliemugenzi) |
-| :-------------------------------------------------------------------------------------------------------------------------------: |
+| [<span><img src="https://github.com/eliemugenzi.png" width="100px;"><div><sub><b>Elie Mugenzi</b></sub></div></span>](https://github.com/eliemugenzi) | [<span><img src="https://github.com/dusmel.png" width="100px;"><div><sub><b>Hadad <img src="https://img.icons8.com/ios/13/000000/twitter--v1.png"/></b></sub></div></span>](https://twitter.com/hadad__) |
+| ------------------------ | ------------------------------ |
+
 
 ## Licence
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -21,6 +21,6 @@ export default {
 
 export const TelcoInitials = ["78", "79", "72",  "73"] as const;
 
-export type  formatTypes = "dashed" | "normalized" | "short" | "formatted" | "dashed-short" |  "dashed-normalized" | "dashed-unformatted" | "space"  |  "space-short" |  "space-normalized"  | "space-unformatted"
+export type  formatTypes = "dashed" | "normalized" | "short" | "dashed-short" |  "dashed-normalized" | "dashed-unformatted" | "space"  |  "space-short" |  "space-normalized"  | "space-unformatted"
 
 // TODO: add type for this object

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,39 @@
+import constants, { formatTypes } from "./constants";
+import splitByIndex from "./helpers/splitByIndex";
+
+export default (unformatted: string, formatShape: formatTypes): string => {
+  switch (formatShape) {
+    case "dashed":
+        return `+(${constants.prefix})-${splitByIndex(unformatted, 3, "dash")}`
+
+    case "dashed-short":
+        return `${splitByIndex(unformatted, 3, "dash")}`
+
+    case "dashed-normalized":
+        return `0${splitByIndex(unformatted, 3, "dash")}`
+
+    case "dashed-unformatted":
+        return `${constants.prefix}-${splitByIndex(unformatted, 3, "dash")}`
+
+    case "space":
+        return `+(${constants.prefix}) ${splitByIndex(unformatted, 3, "space")}`
+
+    case "space-short":
+        return `${splitByIndex(unformatted, 3, "space")}`
+  
+    case "space-normalized":
+        return `0${splitByIndex(unformatted, 3, "space")}`
+  
+    case "space-unformatted":
+        return `${constants.prefix} ${splitByIndex(unformatted, 3, "space")}`
+  
+    case "normalized":
+        return `0${unformatted}`
+
+    case "short":
+        return unformatted
+  
+    default:
+      return "";
+  }
+};

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,7 +1,9 @@
 import constants, { formatTypes } from "./constants";
 import splitByIndex from "./helpers/splitByIndex";
 
-export default (unformatted: string, formatShape: formatTypes): string => {
+export default (unformatted: string, formatShape?: formatTypes): string => {
+  if (!formatShape) return unformatted;
+
   switch (formatShape) {
     case "dashed":
         return `+(${constants.prefix})-${splitByIndex(unformatted, 3, "dash")}`

--- a/src/formatted.ts
+++ b/src/formatted.ts
@@ -1,3 +1,0 @@
-import phoneUtils from ".";
-
-export default (phoneNumber: string) => phoneUtils(phoneNumber).formatted;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,5 @@
-import constants from "./constants";
-import formatted_ from "./formatted";
-import telco_ from "./telco";
-import isValid_ from "./isValid";
-import dashed_ from "./dashed";
-import normalized_ from "./normalized";
-import short_ from "./short";
+import constants, { formatTypes } from "./constants";
+import formatted_ from "./format";
 import splitByIndex from "./helpers/splitByIndex";
 import checkPhoneValidity from "./helpers/checkPhoneValidity";
 
@@ -18,7 +13,7 @@ interface ReturnValues {
   dashed: formatType;
   formatted: formatType;
   unformatted: formatType;
-  // format: () =>
+  format: (shape: formatTypes) => string;
 }
 
 export type PhoneNumberType = (phoneNumber: string) => ReturnValues;
@@ -49,16 +44,11 @@ const phoneUtils: PhoneNumberType = (phoneNumber) => {
     dashed: isValid
       ? `+(${constants.prefix})-${splitByIndex(unformatted, 3, "dash")}`
       : null,
-    // format:
+    format(shape) {
+      return this.isValid ? formatted_(unformatted, shape) : constants.errors.invalid
+    },
   };
 };
-
-export const format = formatted_;
-export const telco = telco_;
-export const isValid = isValid_;
-export const dashed = dashed_;
-export const normalize = normalized_;
-export const short = short_;
 
 export default phoneUtils;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ interface ReturnValues {
   dashed: formatType;
   formatted: formatType;
   unformatted: formatType;
-  format: (shape: formatTypes) => string;
+  format: (shape?: formatTypes) => string;
 }
 
 export type PhoneNumberType = (phoneNumber: string) => ReturnValues;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const phoneUtils: PhoneNumberType = (phoneNumber) => {
     formatted: isValid
       ? `+(${constants.prefix}) ${splitByIndex(unformatted, 3)}`
       : null,
-    unformatted: isValid ? `${constants.prefix}${unformatted}` : null,
+    unformatted: isValid ? `${constants.prefix}${unformatted}` : phoneNumber,
     telco: phoneTelco ? phoneTelco?.label : null,
     short: isValid ? unformatted : null,
     dashed: isValid

--- a/src/tobeDeleted/dashed.ts
+++ b/src/tobeDeleted/dashed.ts
@@ -1,3 +1,3 @@
-import phoneUtils from ".";
+import phoneUtils from "..";
 
 export default (phoneNumber: string) => phoneUtils(phoneNumber).dashed;

--- a/src/tobeDeleted/isValid.ts
+++ b/src/tobeDeleted/isValid.ts
@@ -1,3 +1,3 @@
-import phoneUtils from ".";
+import phoneUtils from "..";
 
 export default (phoneNumber: string) => phoneUtils(phoneNumber).isValid;

--- a/src/tobeDeleted/normalized.ts
+++ b/src/tobeDeleted/normalized.ts
@@ -1,3 +1,3 @@
-import phoneUtils from ".";
+import phoneUtils from "..";
 
 export default (phoneNumber: string) => phoneUtils(phoneNumber).normalized;

--- a/src/tobeDeleted/short.ts
+++ b/src/tobeDeleted/short.ts
@@ -1,3 +1,3 @@
-import phoneUtils from ".";
+import phoneUtils from "..";
 
 export default (phoneNumber: string) => phoneUtils(phoneNumber).short;

--- a/src/tobeDeleted/telco.ts
+++ b/src/tobeDeleted/telco.ts
@@ -1,3 +1,3 @@
-import phoneUtils from ".";
+import phoneUtils from "..";
 
 export default (phoneNumber: string) => phoneUtils(phoneNumber).telco;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -52,6 +52,11 @@ describe("Phone utils", () => {
   });
 
   describe("Check for format function", () => {
+    it("Should return default (short) if shape not provided", () => {
+      const p = phoneUtils("250795844487").format();
+      expect(p).toBe("795844487");
+    });
+    
     it("Should have a normalized format", () => {
       const p = phoneUtils("250795844487").format("normalized");
       expect(p).toBe("0795844487");
@@ -85,6 +90,7 @@ describe("Phone utils", () => {
     });
 
     describe('space format', () => {
+
       it("Should have a space format", () => {
         const p = phoneUtils("250795844487").format("space");
         expect(p).toBe("+(250) 795 844 487");

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,14 +1,14 @@
 import "regenerator-runtime/runtime";
-import phoneUtils, { telco } from "../src";
+import phoneUtils from "../src";
 import constants from "../src/constants";
 
 describe("Phone utils", () => {
   describe("Check the phone numbers telco", () => {
     it("Should return MTN for a number starts with 079", () => {
-      const p = telco("250795844487");
+      const p = phoneUtils("250795844487").telco;
       expect(p).toBe("MTN");
     });
-  })
+  });
 
   describe("Check the phone numbers format", () => {
     it("Should have a dashed format", () => {
@@ -16,7 +16,7 @@ describe("Phone utils", () => {
       expect(p.dashed).toBe("+(250)-795-844-487");
     });
 
-    it("Should have a space format", () => {
+    it("Should have a formatted format", () => {
       const p = phoneUtils("250795844487");
       expect(p.formatted).toBe("+(250) 795 844 487");
     });
@@ -49,5 +49,62 @@ describe("Phone utils", () => {
       expect(p.isValid).toBeFalsy();
       expect(p.error).toBe(constants.errors.short);
     });
+  });
+
+  describe("Check for format function", () => {
+    it("Should have a normalized format", () => {
+      const p = phoneUtils("250795844487").format("normalized");
+      expect(p).toBe("0795844487");
+    });
+
+    it("Should have a short format", () => {
+      const p = phoneUtils("250795844487").format("short");
+      expect(p).toBe("795844487");
+    });
+
+    describe("dashed format", () => {
+      it("Should have a dashed format", () => {
+        const p = phoneUtils("250795844487").format("dashed");
+        expect(p).toBe("+(250)-795-844-487");
+      });
+
+      it("Should have a dashed-short format", () => {
+        const p = phoneUtils("250795844487").format("dashed-short");
+        expect(p).toBe("795-844-487");
+      });
+
+      it("Should have a dashed-normalized format", () => {
+        const p = phoneUtils("250795844487").format("dashed-normalized");
+        expect(p).toBe("0795-844-487");
+      });
+
+      it("Should have a dashed-unformatted format", () => {
+        const p = phoneUtils("250795844487").format("dashed-unformatted");
+        expect(p).toBe("250-795-844-487");
+      });
+    });
+
+    describe('space format', () => {
+      it("Should have a space format", () => {
+        const p = phoneUtils("250795844487").format("space");
+        expect(p).toBe("+(250) 795 844 487");
+      });
+      
+      it("Should have a space-short format", () => {
+        const p = phoneUtils("250795844487").format("space-short");
+        expect(p).toBe("795 844 487");
+      });
+
+      it("Should have a space-normalized format", () => {
+        const p = phoneUtils("250795844487").format("space-normalized");
+        expect(p).toBe("0795 844 487");
+      });
+
+      it("Should have a space-unformatted format", () => {
+        const p = phoneUtils("250795844487").format("space-unformatted");
+        expect(p).toBe("250 795 844 487");
+      });
+    })
+
   });
 });


### PR DESCRIPTION
List of all available formats

| **Format**             | **Output**           |
|------------------------|----------------------|
| `short`                | 780000000            |
| `normalized`           | 0780000000           |
| `dashed`               | +(250)-795-844-487   |
| `dashed-short`         | 795-844-487          |
| `dashed-normalized`    | 0795-844-487         |
| `dashed-unformatted`   | 250-795-844-487      |
| `space`                | +(250) 795 844 487   |
| `space-short`          | 795 844 487          |
| `space-normalized`     | 0795 844 487         |
| `space-unformatted`    | 250 795 844 487      |


Raised the test to 96%

![image](https://user-images.githubusercontent.com/27511264/126071188-3cb3f827-3edf-4e18-a903-e404f617ae5a.png)

