### PR TITLE
fix the replace function breaking on undefined value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,11 @@ interface ReturnValues {
 export type PhoneNumberType = (phoneNumber: string) => ReturnValues;
 
 const phoneUtils: PhoneNumberType = (phoneNumber) => {
-  const phone = phoneNumber.replace(/[^\d.-]/g, "");
-  const unformatted = `${phone}`.substring(
+  const phone = phoneNumber?.replace(/[^\d.-]/g, "");
+  const unformatted = `${phone}`?.substring(
     `${phone}`.length - constants.shortLength
   );
-  const phoneTelco = constants?.telcos.find((t) =>
+  const phoneTelco = constants?.telcos?.find((t) =>
     unformatted.startsWith(`${t.value}`)
   );
   const { isValid, message: errorMessage } = checkPhoneValidity(


### PR DESCRIPTION
The replace function responsible for removing unwanted characters was breaking if the param was undefined, and this is an issue because most values will be coming from the state which is mostly undefined before the component renders 