### PR TITLE
fix "not valid" issue when the input phone number is formatted badly

### DIFF
--- a/src/helpers/checkPhoneValidity.ts
+++ b/src/helpers/checkPhoneValidity.ts
@@ -7,6 +7,8 @@ export default (
 ): { isValid: boolean; message: string } => {
   if (phone.length < constants.shortLength)
     return { isValid: false, message: constants.errors.short };
+  if (phone.length >= constants.fullLength && !phone.startsWith(constants.prefix))
+    return { isValid: false, message: constants.errors.invalid };
   return {
     isValid: !!phoneTelco?.label,
     message: constants.errors.invalid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ interface ReturnValues {
 export type PhoneNumberType = (phoneNumber: string) => ReturnValues;
 
 const phoneUtils: PhoneNumberType = (phoneNumber) => {
-  const phone = phoneNumber?.replace(/[^\d.-]/g, "");
+  const phone = phoneNumber?.replace(/[^\d]/g, "");
   const unformatted = `${phone}`?.substring(
     `${phone}`.length - constants.shortLength
   );
@@ -45,7 +45,9 @@ const phoneUtils: PhoneNumberType = (phoneNumber) => {
       ? `+(${constants.prefix})-${splitByIndex(unformatted, 3, "dash")}`
       : null,
     format(shape) {
-      return this.isValid ? formatted_(unformatted, shape) : constants.errors.invalid
+      return this.isValid
+        ? formatted_(unformatted, shape)
+        : constants.errors.invalid;
     },
   };
 };

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -10,6 +10,33 @@ describe("Phone utils", () => {
     });
   });
 
+  describe("Check validity of badly formated input", () => {
+    const validPhones = [
+      "+(250) 785-323-292",
+      "+250 785 323 292",
+      "0 7 8 5 3 2 3 2 9 2",
+      "2507-85-3232-92",
+    ];
+    it("Should return valid for badly formated phone numbers", () => {
+      validPhones.forEach((phone) => {
+        expect(phoneUtils(phone).isValid).toBe(true);
+      });
+    });
+  });
+
+  describe("Check the phone numbers country code", () => {
+    it("Should fail when passing wrong country code", () => {
+      const wrongCodes = [
+        "+(251) 785-323-292",
+        "+256 785 323 292",
+        "2917-85-3232-92",
+      ];
+      wrongCodes.forEach((phone) => {
+        expect(phoneUtils(phone).isValid).toBe(false);
+      });
+    });
+  });
+
   describe("Check the phone numbers format", () => {
     it("Should have a dashed format", () => {
       const p = phoneUtils("250795844487");
@@ -49,6 +76,11 @@ describe("Phone utils", () => {
       expect(p.isValid).toBeFalsy();
       expect(p.error).toBe(constants.errors.short);
     });
+
+    it("Should be invalid when adding letters", () => {
+      const p = phoneUtils("25078532329a");
+      expect(p.isValid).toBeFalsy();
+    });
   });
 
   describe("Check for format function", () => {
@@ -61,7 +93,7 @@ describe("Phone utils", () => {
       const p = phoneUtils("250795844487").format("unformatted");
       expect(p).toBe("250795844487");
     });
-    
+
     it("Should have a normalized format", () => {
       const p = phoneUtils("250795844487").format("normalized");
       expect(p).toBe("0795844487");
@@ -94,13 +126,12 @@ describe("Phone utils", () => {
       });
     });
 
-    describe('space format', () => {
-
+    describe("space format", () => {
       it("Should have a space format", () => {
         const p = phoneUtils("250795844487").format("space");
         expect(p).toBe("+(250) 795 844 487");
       });
-      
+
       it("Should have a space-short format", () => {
         const p = phoneUtils("250795844487").format("space-short");
         expect(p).toBe("795 844 487");
@@ -115,7 +146,6 @@ describe("Phone utils", () => {
         const p = phoneUtils("250795844487").format("space-unformatted");
         expect(p).toBe("250 795 844 487");
       });
-    })
-
+    });
   });
 });


### PR DESCRIPTION
# What does this PR do?
This PR addresses the issue of returning invalid phone number when the input phone number is formatted badly.
**e.g** `2 5 0 7 8 5 3 2 3 2 9 2` should return true but was returning false.
**e.g** `2507-853 232 92` should return true but was returning false.

## Steps taken to achieve task / **Sub tasks**
Edited the `regular expression` to remove all **white space & dashes** from the input phone number.

## How to test this PR?
- Fetch the package into your project.
- Import and call the `phoneUtils` function with the desired input, and that should produce the output you seek.

## Screenshots
![Screenshot from 2021-07-28 23-00-35](https://user-images.githubusercontent.com/37688326/127396993-bb278d52-836b-4036-8e57-8e5e650266c5.png)


## Issue
[Link](https://github.com/Exuus/rwanda-phone-utils/issues/19)

## Remarks
`N/A`

Closes #19 